### PR TITLE
show name of accelerometer in debug menu

### DIFF
--- a/source/Core/Threads/MOVThread.cpp
+++ b/source/Core/Threads/MOVThread.cpp
@@ -33,7 +33,7 @@ void detectAccelerometerVersion() {
 #ifdef ACCEL_MMA
   if (MMA8652FC::detect()) {
     if (MMA8652FC::initalize()) {
-      DetectedAccelerometerVersion = 1;
+      DetectedAccelerometerVersion = MMA;
     }
   } else
 #endif
@@ -41,7 +41,7 @@ void detectAccelerometerVersion() {
       if (LIS2DH12::detect()) {
     // Setup the ST Accelerometer
     if (LIS2DH12::initalize()) {
-      DetectedAccelerometerVersion = 2;
+      DetectedAccelerometerVersion = LIS;
     }
   } else
 #endif
@@ -49,7 +49,7 @@ void detectAccelerometerVersion() {
       if (BMA223::detect()) {
     // Setup the BMA223 Accelerometer
     if (BMA223::initalize()) {
-      DetectedAccelerometerVersion = 3;
+      DetectedAccelerometerVersion = BMA;
     }
   } else
 #endif
@@ -57,7 +57,7 @@ void detectAccelerometerVersion() {
       if (MSA301::detect()) {
     // Setup the MSA301 Accelerometer
     if (MSA301::initalize()) {
-      DetectedAccelerometerVersion = 4;
+      DetectedAccelerometerVersion = MSA;
     }
   } else
 #endif
@@ -65,7 +65,7 @@ void detectAccelerometerVersion() {
       if (SC7A20::detect()) {
     // Setup the SC7A20 Accelerometer
     if (SC7A20::initalize()) {
-      DetectedAccelerometerVersion = 5;
+      DetectedAccelerometerVersion = SC7;
     }
   } else
 #endif


### PR DESCRIPTION
Instead of displaying numbers in debug menu, show the actual name of the accelerometer.


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
(Bug fix, feature, docs update, ...)



* **What is the current behavior?**
(You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
